### PR TITLE
munge.key generation, change wait method

### DIFF
--- a/controller/docker-entrypoint.sh
+++ b/controller/docker-entrypoint.sh
@@ -41,7 +41,7 @@ _munge_start() {
   chmod 0711 /var/lib/munge
   chmod 0700 /var/log/munge
   chmod 0755 /var/run/munge
-  /sbin/create-munge-key -fr
+  /sbin/create-munge-key -f
   sudo -u munge /sbin/munged
   munge -n
   munge -n | unmunge
@@ -160,13 +160,19 @@ EOF
 # run slurmctld
 _slurmctld() {
   if $USE_SLURMDBD; then
-    if [ ! -f /.secret/slurmdbd.conf ]; then
-      while read i; do
-        if [ "$i" = slurmdbd.conf ]; then
-          break;
-        fi;
-      done < <(inotifywait -e create,open --format '%f' --quiet /.secret --monitor)
-    fi
+    echo -n "cheking for slurmdbd.conf"
+    while [ ! -f /.secret/slurmdbd.conf ]; do
+      echo -n "."
+      sleep 1
+    done
+    echo ""
+    # if [ ! -f /.secret/slurmdbd.conf ]; then
+    #   while read i; do
+    #     if [ "$i" = slurmdbd.conf ]; then
+    #       break;
+    #     fi;
+    #   done < <(inotifywait -e create,open --format '%f' --quiet /.secret --monitor)
+    # fi
   fi
   mkdir -p /var/spool/slurm/ctld \
     /var/spool/slurm/d \

--- a/database/docker-entrypoint.sh
+++ b/database/docker-entrypoint.sh
@@ -37,11 +37,17 @@ _mariadb_start() {
 # start munge using existing key
 _munge_start_using_key() {
   if [ ! -f /.secret/munge.key ]; then
-    while read i; do
-      if [ "$i" = munge.key ]; then
-        break;
-      fi;
-    done < <(inotifywait -e create,open --format '%f' --quiet /.secret --monitor)
+    echo -n "cheking for munge.key"
+    while [ ! -f /.secret/munge.key ]; do
+      echo -n "."
+      sleep 1
+    done
+    echo ""
+    # while read i; do
+    #   if [ "$i" = munge.key ]; then
+    #     break;
+    #   fi;
+    # done < <(inotifywait -e create,open --format '%f' --quiet /.secret --monitor)
   fi
   cp /.secret/munge.key /etc/munge/munge.key
   chown -R munge: /etc/munge /var/lib/munge /var/log/munge /var/run/munge
@@ -73,11 +79,17 @@ _ssh_copy_worker() {
 # wait for worker user in shared /home volume
 _wait_for_worker() {
   if [ ! -f /home/worker/.ssh/id_rsa.pub ]; then
-    while read i; do
-      if [ "$i" = id_rsa.pub ]; then
-        break;
-      fi;
-    done < <(inotifywait -e create,open --format '%f' --quiet /home/worker/.ssh --monitor)
+    echo -n "cheking for id_rsa.pub"
+    while [ ! -f /home/worker/.ssh/id_rsa.pub ]; do
+      echo -n "."
+      sleep 1
+    done
+    echo ""
+    # while read i; do
+    #   if [ "$i" = id_rsa.pub ]; then
+    #     break;
+    #   fi;
+    # done < <(inotifywait -e create,open --format '%f' --quiet /home/worker/.ssh --monitor)
   fi
 }
 

--- a/worker/docker-entrypoint.sh
+++ b/worker/docker-entrypoint.sh
@@ -12,13 +12,19 @@ _sshd_host() {
 
 # start munge using existing key
 _munge_start_using_key() {
-  if [ ! -f /.secret/munge.key ]; then
-    while read i; do
-      if [ "$i" = munge.key ]; then
-        break;
-      fi;
-    done < <(inotifywait -e create,open --format '%f' --quiet /.secret --monitor)
-  fi
+  echo -n "cheking for munge.key"
+  while [ ! -f /.secret/munge.key ]; do
+    echo -n "."
+    sleep 1
+  done
+  echo ""
+  # if [ ! -f /.secret/munge.key ]; then
+  #   while read i; do
+  #     if [ "$i" = munge.key ]; then
+  #       break;
+  #     fi;
+  #   done < <(inotifywait -e create,open --format '%f' --quiet /.secret --monitor)
+  # fi
   cp /.secret/munge.key /etc/munge/munge.key
   chown -R munge: /etc/munge /var/lib/munge /var/log/munge /var/run/munge
   chmod 0700 /etc/munge
@@ -35,11 +41,17 @@ _munge_start_using_key() {
 # setup worker ssh to be passwordless
 _ssh_copy_worker() {
   if [ ! -f /.secret/worker-secret.tar.gz ]; then
-    while read i; do
-      if [ "$i" = worker-secret.tar.gz ]; then
-        break;
-      fi;
-    done < <(inotifywait -e create,open --format '%f' --quiet /.secret --monitor)
+    echo -n "cheking for worker-secret.tar.gz"
+    while [ ! -f /.secret/worker-secret.tar.gz ]; do
+      echo -n "."
+      sleep 1
+    done
+    echo ""
+    # while read i; do
+    #   if [ "$i" = worker-secret.tar.gz ]; then
+    #     break;
+    #   fi;
+    # done < <(inotifywait -e create,open --format '%f' --quiet /.secret --monitor)
   fi
   cp /.secret/worker-secret.tar.gz /home/worker
   chown worker: /home/worker/worker-secret.tar.gz
@@ -49,22 +61,34 @@ _ssh_copy_worker() {
 # wait for worker user in shared /home volume
 _wait_for_worker() {
   if [ ! -f /home/worker/.ssh/id_rsa.pub ]; then
-    while read i; do
-      if [ "$i" = id_rsa.pub ]; then
-        break;
-      fi;
-    done < <(inotifywait -e create,open --format '%f' --quiet /home/worker/.ssh --monitor)
+    echo -n "cheking for id_rsa.pub"
+    while [ ! -f /home/worker/.ssh/id_rsa.pub ]; do
+      echo -n "."
+      sleep 1
+    done
+    echo ""
+    # while read i; do
+    #   if [ "$i" = id_rsa.pub ]; then
+    #     break;
+    #   fi;
+    # done < <(inotifywait -e create,open --format '%f' --quiet /home/worker/.ssh --monitor)
   fi
 }
 
 # run slurmd
 _slurmd() {
   if [ ! -f /.secret/slurm.conf ]; then
-    while read i; do
-      if [ "$i" = slurm.conf ]; then
-        break;
-      fi;
-    done < <(inotifywait -e create,open --format '%f' --quiet /.secret --monitor)
+    echo -n "cheking for slurm.conf"
+    while [ ! -f /.secret/slurm.conf ]; do
+      echo -n "."
+      sleep 1
+    done
+    echo ""
+    # while read i; do
+    #   if [ "$i" = slurm.conf ]; then
+    #     break;
+    #   fi;
+    # done < <(inotifywait -e create,open --format '%f' --quiet /.secret --monitor)
   fi
   mkdir -p /var/spool/slurm/d
   chown slurm: /var/spool/slurm/d


### PR DESCRIPTION
- Remove -r flag from munge.key generation due to no user input, 
- revert to using sleep statements while waiting for files instead of inotifywait as it caused issues with GlusterFS mounts