### PR TITLE
Fix mariadb not finding resolveip

### DIFF
--- a/database/docker-entrypoint.sh
+++ b/database/docker-entrypoint.sh
@@ -26,6 +26,8 @@ _slurm_acct_db() {
 
 # start database
 _mariadb_start() {
+  # mariadb somehow expects `resolveip` to be found under this path; see https://github.com/SciDAS/slurm-in-docker/issues/26
+  ln -s /usr/bin/resolveip /usr/libexec/resolveip
   mysql_install_db
   chown -R mysql: /var/lib/mysql/ /var/log/mariadb/ /var/run/mariadb
   cd /var/lib/mysql


### PR DESCRIPTION
This realizes the solution idea from #26. We simply create a symlink so mariadb finds `resolveip` where it expects it.

Fixes #26.